### PR TITLE
[TASK] Keep (future) development files from getting packaged

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/Tests/ export-ignore
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/.travis.yml export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/phpcs.xml.dist export-ignore


### PR DESCRIPTION
Development files should not be part of the packages generated by
GitHub and installable via Composer - both to keep package size
small as well as to improve security.